### PR TITLE
fix deprecated configuration

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,6 @@ android {
         }
     }
     compileSdkVersion 26
-    buildToolsVersion '26.0.2'
     defaultConfig {
         applicationId "org.beiwe.app"
         minSdkVersion 16
@@ -80,8 +79,8 @@ repositories {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:26.1.0'
-    compile 'com.commonsware.cwac:anddown:0.3.0'
-    compile 'io.sentry:sentry-android:1.7.3'
-    compile 'com.madgag.spongycastle:core:1.54.0.0'
+    implementation 'com.android.support:appcompat-v7:26.1.0'
+    implementation 'com.commonsware.cwac:anddown:0.3.0'
+    implementation 'io.sentry:sentry-android:1.7.3'
+    implementation 'com.madgag.spongycastle:core:1.54.0.0'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,9 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.beiwe.app">
 
-    <uses-sdk
-        android:minSdkVersion="16"
-        android:targetSdkVersion="23" />
+
 
     <!-- GPS and network-location service -->
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />

--- a/app/src/main/java/org/beiwe/app/survey/MarkDownTextView.java
+++ b/app/src/main/java/org/beiwe/app/survey/MarkDownTextView.java
@@ -2,6 +2,7 @@ package org.beiwe.app.survey;
 
 import android.content.Context;
 import android.text.Html;
+import android.text.method.LinkMovementMethod;
 import android.util.AttributeSet;
 import android.widget.TextView;
 
@@ -21,9 +22,10 @@ public class MarkDownTextView extends TextView {
 	/** Takes a markdown formatted String and applies the formatting to the TextView object.
 	 * @param markDownText markdown formatted text string */
 	public void setMarkDownText(String markDownText) {
-		AndDown markedownConverter = new AndDown();
-		String markDownHtml = markedownConverter.markdownToHtml(markDownText);
+		AndDown markDownConverter = new AndDown();
+		String markDownHtml = markDownConverter.markdownToHtml(markDownText);
 		super.setText( Html.fromHtml(markDownHtml) );
+		super.setMovementMethod(LinkMovementMethod.getInstance());
 	}
 
 	/** This should make usage trivial, just use the settext function on

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.3.0'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Nov 05 10:30:11 EST 2017
+#Wed Jan 30 12:15:43 CST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip


### PR DESCRIPTION
dependencies use ```implementation``` instead of ```compile```

More info here: https://github.com/google/dagger/issues/1141

It is not necessary to specify the Android SDK Build Tools as 26.0.2 because it is below the minimum supported version for the current gradle plugin (3.3.0).

The ```targetSdk``` version should not be declared in the android manifest file. If it is necessary, it can be moved to defaultConfig in the build.gradle