### PR TITLE
When sanitizing data, use periods instead of semicolons

### DIFF
--- a/app/src/main/java/org/beiwe/app/survey/SurveyAnswersRecorder.java
+++ b/app/src/main/java/org/beiwe/app/survey/SurveyAnswersRecorder.java
@@ -178,7 +178,7 @@ public class SurveyAnswersRecorder {
 
 				// If this CheckBox is selected, add it to the list of selected answers
 				if (checkBox.isChecked()) {
-					answersList += checkBox.getText().toString() + ", ";
+					answersList += checkBox.getText().toString() + "; ";
 				}
 			}
 		}

--- a/app/src/main/java/org/beiwe/app/survey/SurveyTimingsRecorder.java
+++ b/app/src/main/java/org/beiwe/app/survey/SurveyTimingsRecorder.java
@@ -77,7 +77,7 @@ public class SurveyTimingsRecorder {
 	public static String sanitizeString(String input) {
 		input = input.replaceAll("[\t\n\r]", "  ");
 		// Replace all commas in the text with semicolons, because commas are the delimiters
-		input = input.replaceAll(",", ";");
+		input = input.replaceAll(",", ".");
 		return input;
 	}
 


### PR DESCRIPTION
`question answer options` are separated using semicolons, so using semicolons to sanitize commas causes a bug further down the line in analysis: [https://github.com/onnela-lab/beiwe-backend/issues/53](https://github.com/onnela-lab/beiwe-backend/issues/53). 

Additionally, since `question answer options` are already separated using semicolons and commas are no longer converted to semicolons, separate multiple checkbox answers with semicolons instead of commas.