### PR TITLE
adds additional fields to sentry errors if the data is provided from the server at registration

### DIFF
--- a/app/src/main/java/org/beiwe/app/CrashHandler.kt
+++ b/app/src/main/java/org/beiwe/app/CrashHandler.kt
@@ -54,6 +54,7 @@ class CrashHandler(private val errorHandlerContext: Context) : Thread.UncaughtEx
             Sentry.getContext().addTag("server_url", PostRequest.addWebsitePrefix(""))
             Sentry.getContext().addTag("study_name", PersistentData.getStudyName())
             Sentry.getContext().addTag("study_id", PersistentData.getStudyID())
+            Sentry.getContext().addTag("product_flavor", BuildConfig.FLAVOR)
             Sentry.capture(exception);
         }
     }

--- a/app/src/main/java/org/beiwe/app/CrashHandler.kt
+++ b/app/src/main/java/org/beiwe/app/CrashHandler.kt
@@ -50,9 +50,17 @@ class CrashHandler(private val errorHandlerContext: Context) : Thread.UncaughtEx
          * @param context An android Context*/
         @JvmStatic
         fun writeCrashlog(exception: Throwable?, context: Context?) {
-            Sentry.getContext().addTag("user_id", PersistentData.getPatientID())
+            Log.w("sentrylog", "entered crashlog function")
+            /*Sentry.getContext().addTag("user_id", PersistentData.getPatientID())
             Sentry.getContext().addTag("server_url", PostRequest.addWebsitePrefix(""))
+            Sentry.getContext().addTag("study_name", "sample study name")
+            Sentry.getContext().addTag("study_id", "sample study ")*/
+            //Sentry.getContext().addTag("study_name", PersistentData.getStudyName())
+            //Sentry.getContext().addTag("study_id", PersistentData.getStudyID())
+            Sentry.getContext().addTag("study_name", "sample study name")
+            Sentry.getContext().addTag("study_id", "sample study ")
             Sentry.capture(exception)
+            Log.w("sentrylog", "finished sentry report")
         }
     }
 

--- a/app/src/main/java/org/beiwe/app/CrashHandler.kt
+++ b/app/src/main/java/org/beiwe/app/CrashHandler.kt
@@ -50,13 +50,11 @@ class CrashHandler(private val errorHandlerContext: Context) : Thread.UncaughtEx
          * @param context An android Context*/
         @JvmStatic
         fun writeCrashlog(exception: Throwable?, context: Context?) {
-            Log.w("sentrylog", "entered crashlog function")
             Sentry.getContext().addTag("user_id", PersistentData.getPatientID())
             Sentry.getContext().addTag("server_url", PostRequest.addWebsitePrefix(""))
             Sentry.getContext().addTag("study_name", PersistentData.getStudyName())
             Sentry.getContext().addTag("study_id", PersistentData.getStudyID())
             Sentry.capture(exception);
-            Log.w("sentrylog", "finished sentry report");
         }
     }
 

--- a/app/src/main/java/org/beiwe/app/CrashHandler.kt
+++ b/app/src/main/java/org/beiwe/app/CrashHandler.kt
@@ -51,16 +51,12 @@ class CrashHandler(private val errorHandlerContext: Context) : Thread.UncaughtEx
         @JvmStatic
         fun writeCrashlog(exception: Throwable?, context: Context?) {
             Log.w("sentrylog", "entered crashlog function")
-            /*Sentry.getContext().addTag("user_id", PersistentData.getPatientID())
+            Sentry.getContext().addTag("user_id", PersistentData.getPatientID())
             Sentry.getContext().addTag("server_url", PostRequest.addWebsitePrefix(""))
-            Sentry.getContext().addTag("study_name", "sample study name")
-            Sentry.getContext().addTag("study_id", "sample study ")*/
-            //Sentry.getContext().addTag("study_name", PersistentData.getStudyName())
-            //Sentry.getContext().addTag("study_id", PersistentData.getStudyID())
-            Sentry.getContext().addTag("study_name", "sample study name")
-            Sentry.getContext().addTag("study_id", "sample study ")
-            Sentry.capture(exception)
-            Log.w("sentrylog", "finished sentry report")
+            Sentry.getContext().addTag("study_name", PersistentData.getStudyName())
+            Sentry.getContext().addTag("study_id", PersistentData.getStudyID())
+            Sentry.capture(exception);
+            Log.w("sentrylog", "finished sentry report");
         }
     }
 

--- a/app/src/main/java/org/beiwe/app/networking/PostRequest.java
+++ b/app/src/main/java/org/beiwe/app/networking/PostRequest.java
@@ -208,12 +208,7 @@ public class PostRequest {
 				if (responseJSON.has("study_id") && responseJSON.has("study_name")) {
 					PersistentData.setStudyID(responseJSON.getString("study_id"));
 					PersistentData.setStudyName(responseJSON.getString("study_name"));
-					//log.w(responseJSON.getString("study_id"));
-					//log.w(responseJSON.getString("study_name"));
 				}
-				Log.w("sentrylog", "finished registering");
-				String mystring = responseJSON.getString("sadlkjfadslkjaslkj");
-
 			} catch (JSONException e) {
 				// If it caught a JSONException, the likeliest cause is that the server returned a
 				// 200 response code but didn't send a key or device settings, which means it's not

--- a/app/src/main/java/org/beiwe/app/networking/PostRequest.java
+++ b/app/src/main/java/org/beiwe/app/networking/PostRequest.java
@@ -205,6 +205,15 @@ public class PostRequest {
 				writeKey(key, response);
 				JSONObject deviceSettings = responseJSON.getJSONObject("device_settings");
 				SetDeviceSettings.writeDeviceSettings(deviceSettings);
+				if (responseJSON.has("study_id") && responseJSON.has("study_name")) {
+					PersistentData.setStudyID(responseJSON.getString("study_id"));
+					PersistentData.setStudyName(responseJSON.getString("study_name"));
+					//log.w(responseJSON.getString("study_id"));
+					//log.w(responseJSON.getString("study_name"));
+				}
+				Log.w("sentrylog", "finished registering");
+				String mystring = responseJSON.getString("sadlkjfadslkjaslkj");
+
 			} catch (JSONException e) {
 				// If it caught a JSONException, the likeliest cause is that the server returned a
 				// 200 response code but didn't send a key or device settings, which means it's not

--- a/app/src/main/java/org/beiwe/app/storage/PersistentData.java
+++ b/app/src/main/java/org/beiwe/app/storage/PersistentData.java
@@ -395,8 +395,8 @@ public class PersistentData {
 	public static void setStudyName(String studyName) {
 		putCommit(STUDY_NAME, studyName);
 	}
-	public static String getStudyID() { return pref.getString(STUDY_NAME, NULL_ID); }
-	public static String getStudyName() { return pref.getString(STUDY_ID, NULL_ID); }
+	public static String getStudyID() { return pref.getString(STUDY_ID, NULL_ID); }
+	public static String getStudyName() { return pref.getString(STUDY_NAME, NULL_ID); }
 
 	/*###########################################################################################
 	#################################### Contact Numbers ########################################

--- a/app/src/main/java/org/beiwe/app/storage/PersistentData.java
+++ b/app/src/main/java/org/beiwe/app/storage/PersistentData.java
@@ -36,7 +36,9 @@ public class PersistentData {
 	private static final String KEY_ID = "uid";
 	private static final String KEY_PASSWORD = "password";
 	private static final String IS_REGISTERED = "IsRegistered";
-
+	private static final String STUDY_NAME = "study_name";
+	private static final String STUDY_ID = "study_id";
+	
 	private static final String LOGIN_EXPIRATION = "loginExpirationTimestamp";
 	private static final String PCP_PHONE_KEY = "primary_care";
 	private static final String PASSWORD_RESET_NUMBER_KEY = "reset_number";
@@ -382,6 +384,20 @@ public class PersistentData {
 	public static String getPassword() { return pref.getString( KEY_PASSWORD, null ); }
 	public static String getPatientID() { return pref.getString(KEY_ID, NULL_ID); }
 
+
+	/*###########################################################################################
+	###################################### ERROR INFO #########################################
+	###########################################################################################*/
+
+	public static void setStudyID(String studyID) {
+		putCommit(STUDY_ID, studyID);
+	}
+	public static void setStudyName(String studyName) {
+		putCommit(STUDY_NAME, studyName);
+	}
+	public static String getStudyID() { return pref.getString(STUDY_NAME, NULL_ID); }
+	public static String getStudyName() { return pref.getString(STUDY_ID, NULL_ID); }
+
 	/*###########################################################################################
 	#################################### Contact Numbers ########################################
 	###########################################################################################*/
@@ -606,4 +622,3 @@ public class PersistentData {
 		putCommit(CALL_RESEARCH_ASSISTANT_BUTTON_ENABLED_KEY, enabled);
 	}
 }
-


### PR DESCRIPTION
adds a field for the phonetic study name as well as the UUID study Id field in all sentry errors.

this data will appear as null if not provided on server registration, which is currently only implemented in the Beiwe-backend `Firebase-Config` branch.