### PR TITLE
[fix-androidx-core-dependency] I failed to lock the androidx core lib…

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -111,7 +111,7 @@ dependencies {
     implementation 'com.madgag.spongycastle:core:1.54.0.0'
     implementation 'com.google.firebase:firebase-messaging:20.2.3'
     implementation 'com.google.firebase:firebase-analytics:17.4.4'
-    implementation "androidx.core:core-ktx:+"
+    implementation "androidx.core:core-ktx:1.6.0"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     apply plugin: 'kotlin-android-extensions'
 


### PR DESCRIPTION
…rary version, it was auto-grabbing one with an sdk 31 (android 12) os requirement.

new pinned version, 1.6.0, is the current stable release.


This should have no effect on the app at all, as far as I can tell the new version of this library is one still-in-beta point-release forward of 1.6.0 at 1.7.0beta2.