### PR TITLE
Allow numbers between 8 and 15 characters/localizations for German/Italian

### DIFF
--- a/app/src/main/java/org/beiwe/app/ui/registration/PhoneNumberEntryActivity.kt
+++ b/app/src/main/java/org/beiwe/app/ui/registration/PhoneNumberEntryActivity.kt
@@ -12,7 +12,8 @@ import org.beiwe.app.survey.TextFieldKeyboard
 import org.beiwe.app.ui.utils.AlertsManager
 
 class PhoneNumberEntryActivity : RunningBackgroundServiceActivity() {
-    private val phoneNumberLength = 10
+    private val minPhoneNumberLength = 8
+    private val maxPhoneNumberLength = 15
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -41,8 +42,12 @@ class PhoneNumberEntryActivity : RunningBackgroundServiceActivity() {
                 AlertsManager.showAlert(getString(R.string.enter_clinician_number), this)
                 return
             }
-            if (primary.length != phoneNumberLength) {
-                AlertsManager.showAlert(String.format(getString(R.string.phone_number_length_error), phoneNumberLength), this)
+            if (primary.length < minPhoneNumberLength) {
+                AlertsManager.showAlert(String.format(getString(R.string.phone_number_length_min_error), minPhoneNumberLength), this)
+                return
+            }
+            if (primary.length > maxPhoneNumberLength) {
+                AlertsManager.showAlert(String.format(getString(R.string.phone_number_length_max_error), maxPhoneNumberLength), this)
                 return
             }
         }
@@ -51,8 +56,12 @@ class PhoneNumberEntryActivity : RunningBackgroundServiceActivity() {
                 AlertsManager.showAlert(getString(R.string.enter_research_assitant_number), this)
                 return
             }
-            if (reset.length != phoneNumberLength) {
-                AlertsManager.showAlert(String.format(getString(R.string.phone_number_length_error), phoneNumberLength), this)
+            if (reset.length < minPhoneNumberLength) {
+                AlertsManager.showAlert(String.format(getString(R.string.phone_number_length_min_error), minPhoneNumberLength), this)
+                return
+            }
+            if (reset.length > maxPhoneNumberLength) {
+                AlertsManager.showAlert(String.format(getString(R.string.phone_number_length_max_error), maxPhoneNumberLength), this)
                 return
             }
         }

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -1,0 +1,202 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <!-- Reference strings in Java code using a line like this:
+    appContext.getResources().getString(R.string.name_of_string) -->
+
+    <!-- General Strings -->
+    <string name="action_settings">Einstellungen</string>
+
+    <!-- Permissions Strings -->
+    <string name="permissions_alert_title">"Voraussetzung zur Berechtigung : "</string>
+    <string name="permission_normal_request_template">Für diese Studie benötigt Beiwe die Berechtigung zu %s. Bitte drücken Sie auf „Zulassen“ für die folgende Berechtigungsanfrage.</string>
+    <string name="permission_bumping_request_template">Damit die Anmeldung für die Studie gelingt, benötigt Beiwe die Berechtigung für %s. Diese Berechtigung scheint deaktiviert zu sein. Sie werden zu den Einstellungen der Beiwe-App weitergeleitet, damit Sie die Berechtigung manuell aktivieren können.</string>
+    <string name="permission_registration_read_sms_alert">Um sich für eine Studie anzumelden, benötigt Beiwe Zugang zu einigen Telefondiensten dieses Geräts. Bitte drücken Sie „Zulassen“, wenn Sie ein Menü sehen, in dem Berechtigungen für den Zugriff auf SMS angefordert werden. Abhängig vom Studientyp können Sie diese Berechtigung nach Abschluss der Registrierung in den Einstellungen der Beiwe-App deaktivieren.</string>
+    <string name="permission_registration_actually_need_sms_alert">Beiwe benötigt SMS-Berechtigungen, um Sie für eine Studie anzumelden, aber diese Berechtigung scheint deaktiviert zu sein. Sie werden zu den Einstellungen der Beiwe-App weitergeleitet, damit Sie die SMS-Berechtigung manuell aktivieren können.</string>
+    <string name="power_management_exception_alert">Diese Berechtigungsabfrage, die Sie gleich sehen werden, ist erforderlich, damit die Beiwe-App im Hintergrund ausgeführt werden kann.</string>
+    <string name="cant_make_phone_call_alert_title">Beiwe kann keine Telefonate durchführen</string>
+    <string name="cant_make_a_phone_call_permissions_alert">Damit Beiwe einen Telefonanruf durchführen kann, müssen Sie unter [Einstellungen] -> [Berechtigungen] und der Beiwe-App die Berechtigung \"Telefon\" erteilen.\\n\\n Oder Sie können die Telefon-App öffnen und den Anruf selbst tätigen.</string>
+    <string name="go_to_settings_button">zu den Einstellungen gehen</string>
+    <string name="permission_access_fine_location">Ortungsdienste verwenden</string>
+    <string name="permission_access_network_state">Netzwerkeinstellungen anzeigen</string>
+    <string name="permission_access_wifi_state">WLAN-Verbindung anzeigen</string>
+    <string name="permission_read_sms">Ihre SMS-Nachrichten anzeigen</string>
+    <string name="permission_bluetooth">Bluetooth verwenden</string>
+    <string name="permission_bluetooth_admin">Bluetooth verwenden</string>
+    <string name="permission_call_phone">auf ihren Telefondienst zugreifen</string>
+    <string name="permission_internet">auf das Internet zugreifen</string>
+    <string name="permission_read_call_log">auf Ihren Telefondienst zugreifen</string>
+    <string name="permission_read_contacts">auf Ihre Kontakte zugreifen</string>
+    <string name="permission_read_phone_state">auf Ihren Telefondienst zugreifen</string>
+    <string name="permission_receive_boot_completed">App beim Hochfahren des Telefons starten</string>
+    <string name="permission_record_audio">auf Ihr Mikrofon zugreifen</string>
+    <string name="permission_access_coarse_location">Ortungsdienste verwenden</string>
+    <string name="permission_receive_mms">MMS-Nachrichten empfangen</string>
+    <string name="permission_receive_sms">SMS-Nachrichten empfangen</string>
+    <string name="permission_access_background_location">Standort verwenden: „Immer zulassen\“</string>
+
+    <!-- API URLs -->
+
+    <!-- Recording Options Strings -->
+    <string name="title_activity_audio_recorder">Audio-Befragung Fragen aufnehmen</string>
+    <string name="button_play">abspielen</string>
+    <string name="button_record">aufnehmen</string>
+
+    <!-- Debug Menu Strings -->
+    <string name="title_activity_survey">Befragung</string>
+
+    <!-- Error Messages -->
+    <string name="default_alert_title">Fehler</string>
+    <string name="alert_ok_button_text">OK</string>
+    <string name="alert_cancel_button_text">Abbrechen</string>
+    <string name="question_error_text">If you are reading this, something broke. Please contact the study administrators, and tell them that there is a bug in the survey!</string>
+    <string name="invalid_device">Dieses Gerät erfüllt nicht die Mindestanforderungen für diese App. Um Probleme zu vermeiden, deinstallieren Sie bitte die App.</string>
+    <string name="invalid_encryption_key">Received an invalid encryption key, please contact the a Beiwe administrator.</string>
+    <string name="http_message_200">OK</string>
+    <string name="http_message_1">Someone misconfigured the server! Please contact research staff.</string>
+    <string name="http_message_400">Das Gerät konnte nicht mit diesem Benutzername registriert werden. Bitte wenden Sie sich an das Personal Ihrer Studie.</string>
+    <string name="http_message_403_during_registration">Bitte bestätigen Sie, dass die URL korrekt ist. Beiwe konnte keine Verbindung zum Server herstellen.</string>
+    <string name="http_message_403_wrong_password">das aktuelles Passwort wurde falsch eingegeben</string>
+    <string name="http_message_403_wrong_password_forgot_password_page">das vorläufiges Passwort wurde falsch eingegeben</string>
+    <string name="http_message_405">Der von Ihnen verwendete Benutzername wurde bereits registriert. Bitte bestätigen Sie Ihren Benutzernamen mit den Mitarbeitern Ihrer Studie, um die Registrierung abzuschließen.</string>
+    <string name="http_message_internet_disconnected">Sie sind nicht mit dem Internet verbunden. Bitte stellen Sie eine Internetverbindung her und versuchen Sie es erneut.</string>
+    <string name="http_message_server_not_found">Bitte bestätigen Sie, dass die URL korrekt ist. Beiwe konnte keine Verbindung zum Server herstellen.</string>
+    <string name="http_message_unknown_response_code">Ein unbekannter Fehler ist bei Beiwe aufgetreten</string>
+
+    <!-- Survey Activity Strings -->
+    <string name="survey_next_button_text">Weiter</string>
+    <string name="survey_submit_button">Befragung abschicken</string>
+    <string name="default_survey_submit_success_message">Vielen Dank für die Beantwortung der Fragen. Ein Mitglied des Forschungsteams kann Ihre Antworten nicht sofort einsehen. Wenn Sie also Hilfe benötigen oder daran denken, sich selbst zu verletzen, wenden Sie sich bitte an Ihren Arzt. Sie können auch auf die Schaltfläche \"Forschungsteam kontaktieren\" klicken.</string>
+    <string name="survey_submit_error_message">Ein unbekannter Fehler ist bei Beiwe aufgetreten</string>
+    <string name="survey_loading_text" tools:ignore="TypographyEllipsis">die neueste Befragung wird vom Server heruntergeladen...</string>
+
+    <!-- Login Activity Strings -->
+    <string name="login_page_for_app">Anmeldung zur Studie</string>
+    <string name="login_activity_please_enter_password">Passwort:</string>
+    <string name="incorrect_user_pass_combo">Entschuldigung, der Benutzername oder das Passwort, das Sie eingegeben haben, ist falsch.</string>
+    <string name="title_activity_register">Anmelden</string>
+    <string name="title_activity_login">Login</string>
+    <string name="title_activity_login_string">Login</string>
+    <string name="login_activity_welcoming_message">Anmeldung zur Studie</string>
+    <string name="user_id_system_mismatch">Entschuldigung, der Benutzername oder das Passwort, das Sie eingegeben haben, ist falsch.</string>
+    <string name="password_system_mismatch">Entschuldigung, der Benutzername oder das Passwort, das Sie eingegeben haben, ist falsch.</string>
+
+    <!-- Reset Password Activity Strings -->
+    <string name="title_activity_reset_password">Passwort ändern</string>
+    <string name="reset_password_title">Passwort ändern</string>
+    <string name="reset_password_current_password_caption">aktuelles Passwort:</string>
+    <string name="reset_password_new_password_caption">neues Passwort:</string>
+    <string name="reset_password_confirm_new_password_caption">neues Passwort bestätigen:</string>
+    <string name="reset_password_submit">Passwort ändern</string>
+    <string name="reset_password_error_alert_title">Passwortaktualisierung fehlgeschlagen</string>
+    <string name="invalid_old_password">das Passwort wurde falsch eingegeben</string>
+    <string name="pass_reset_complete">Ihr Passwort wurde erfolgreich geändert</string>
+    <string name="password_mismatch">neues Passwort wurde falsch eingegeben</string>
+    <string name="password_too_short">YIhr neues Passwort muss mindestens %d Zeichen lang sein</string>
+
+    <!-- Forgot Password Activity Strings -->
+    <string name="title_activity_forgot_password">Passwort vergessen</string>
+    <string name="forgot_password_title">Wenden Sie sich bitte an Ihr Forschungsteam und teilen Sie ihnen Ihren Benutzernamen mit, damit sie Ihnen ein vorläufiges Passwort geben können.</string>
+    <string name="forgot_password_instructions_text">Ihr Benutzername ist \"%s\"; bitte verwenden Sie diesen Benutzernamen und nicht Ihren Namen.</string>
+    <string name="forgot_password_call_button_text">technischen Unterstützung anrufen</string>
+    <string name="forgot_password_temporary_password_caption">vorläufiges Passwort:</string>
+
+    <!-- Registration Activity Strings -->
+    <string name="registration_welcome_message">Willkommen in der Beiwe-App</string>
+    <string name="registration_server_url_label">Studien-URL</string>
+    <string name="registration_server_url_hint">Zum Beispiel www.eu.beiwe.org</string>
+    <string name="registration_user_id_label">Benutzername:</string>
+    <string name="registration_user_id_hint">Benutzername</string>
+    <string name="registration_temp_password_label">vorläufiges Passwort:</string>
+    <string name="registration_temp_password_hint">vorläufiges Passwort</string>
+    <string name="registration_new_password_label">neues Passwort:</string>
+    <string name="registration_new_password_hint">mindestens 6 Zeichen</string>
+    <string name="registration_confirm_new_password_label">Passwort bestätigen</string>
+    <string name="registration_confirm_new_password_hint">mindestens 6 Zeichen</string>
+    <string name="registration_replacement_password_hint">mindestens %d Zeichen</string>
+    <string name="registration_submit">Anmelden</string>
+    <string name="title_activity_loading">Beiwe wird geladen</string>
+    <string name="empty_temp_password">Bitte geben Sie das temporäre Passwort ein, das Sie vom Studienteam erhalten haben.</string>
+    <string name="url_too_short">Bitte geben Sie Ihre Studien-URL ein</string>
+    <string name="invalid_user_id">Bitte geben Sie Ihren Benutzernamen ein</string>
+    <string name="invalid_password">das Passwort wurde falsch eingegeben</string>
+    <string name="couldnt_register">Registrierung fehlgeschlagen</string>
+
+    <!-- Phone Numbers -->
+    <string name="title_activity_phone_number_entry">Telefonnummern</string>
+    <string name="number_entry_top_message">Telefonnummern</string>
+    <string name="number_entry_button">Geben Sie die Telefonnummern ein</string>
+    <string name="phone_number_entry_your_clinician_label">Telefonnummer der Studienunterstützung</string>
+    <string name="phone_number_entry_your_clinician_hint">12 Ziffern</string>
+    <string name="phone_number_entry_research_assistant_label">Telefonnummer für technischen Unterstützung</string>
+    <string name="phone_number_entry_research_assistant_hint">12 Ziffern</string>
+
+    <!-- Loading Activity Strings -->
+    <string name="loading_activity_loading_message" tools:ignore="TypographyEllipsis">Beiwe wird geladen</string>
+    <string name="survey_notification_title_template">Befragung: %s</string>
+    <string name="action_share">teilen</string>
+    <string name="action_reply">Antwort</string>
+
+    <!-- Main menu strings -->
+    <string name="title_activity_main_menu">Beiwe Hauptbildschirm</string>
+    <string name="main_menu_top_message">Willkommen in der Beiwe-App</string>
+    <string name="main_menu_view_graph">Antworten in Grafik anzeigen</string>
+    <string name="default_call_clinician_text">Studienunterstützung anrufen</string>
+    <string name="title_activity_graph">Vorherige Antworten</string>
+    <string name="permasurvey">permasurvey</string>
+    <string name="perm_survey">Befragung</string>
+    <string name="permaaudiosurvey">Audiobefragung</string>
+
+    <!-- Recording Activity -->
+    <string name="record_activity_default_message">We would like to know how your day is going.  When you are ready, please press \"Record\" and speak for about 2 minutes.  Press \"Stop\" when you are finished. The recording will stop automatically after 4 minutes. Remember, researchers will not review and analyze your data until the end of the study, so if you are ill or in danger and need to speak with your clinician, press the \"Call My Clinician\" button.</string>
+    <string name="record_activity_button">aufnehmen</string>
+    <string name="record_activity_playback">abspielen</string>
+    <string name="play_button_text">abspielen</string>
+    <string name="play_button_stop_text">stoppen</string>
+    <string name="record_button_text">aufnehmen</string>
+    <string name="record_button_stop_text">stoppen</string>
+    <string name="done_button_text">speichern</string>
+    <string name="timeout_msg_1st_half">"Die Sprachaufnahme darf nicht länger als "</string>
+    <string name="timeout_msg_2nd_half">" Minuten sein, daher wurde die Aufnahme automatisch gestoppt und gespeichert"</string>
+
+    <!-- Notifications -->
+    <string name="survey_notification_app_name">Beiwe</string>
+    <string name="new_android_survey_notification_ticker">"Eine neue Befragung steht bereit "</string>
+    <string name="new_android_survey_notification_details">Bitte beantworten Sie die Fragen.</string>
+    <string name="new_audio_survey_notification_ticker">Eine neue Audiobefragung steht bereit</string>
+    <string name="new_audio_survey_notification_details">Bitte aufnehmen Sie die Audiobefragung.</string>
+
+    <!-- Notification Action Pointers -->
+
+    <!-- Timer Action Strings -->
+
+    <!-- Menu Items -->
+    <string name="menu_sign_out">Abmelden</string>
+    <string name="menu_change_password">Passwort ändern</string>
+    <string name="menu_about">Über diese App</string>
+    <string name="call_research_assistant">technische Unterstützung anrufen</string>
+    <string name="view_survey_answers">Antworten anzeigen</string>
+
+    <!-- About Page -->
+    <string name="title_activity_about">Über Beiwe</string>
+    <string name="default_about_page_text">Beiwe ist eine Anwendung, die auf Ihrem Handy läuft und Forschern hilft, Informationen über Ihre Gesundheit und Ihr Verhalten zu sammeln. Es fordert Sie auf, einmal täglich kurze Fragen zu beantworten und eine Aufnahme Ihrer Stimme zu machen. Beiwe sammelt kontinuierlich Informationen über Ihren Standort (unter Verwendung des GPS Ihres Telefons) und darüber, wie viel Sie sich bewegen (unter Verwendung des Beschleunigungsmessers Ihres Telefons). Es registriert auch, wie oft Sie Ihr Telefon für Anrufe und SMS verwenden, und es erhält einen Überblick über die Anzahl der verschiedenen Personen, mit denen Sie kommunizieren. Wichtig ist, dass Beiwe keine Namen oder Telefonnummern von Personen aufzeichnet, mit denen Sie kommunizieren. Es kann zwar feststellen, ob Sie dieselbe Person mehr als einmal anrufen, aber es weiß nicht, wer diese Person ist. Beiwe zeichnet den Inhalt Ihrer Textnachrichten oder Telefonate nicht auf. Es verfolgt auch die verschiedenen Wi-Fi-Netzwerke in Ihrer Nähe, aber die Namen dieser Netzwerke werden durch zufällige Codes ersetzt. Weiterhin kann Beiwe feststellen, ob Sie sich in der Nähe eines anderen Telefons befinden, auf dem diese Anwendung ebenfalls ausgeführt wird.\\n\\nObwohl Beiwe große Datenmengen sammelt, werden alle diese Daten so verarbeitet, dass Ihre Privatsphäre geschützt ist. Das bedeutet, dass die Anwendung weder Ihren Namen noch Ihre Telefonnummer oder irgendetwas anderes kennt, das Sie identifizieren könnte. Beiwe kennt Sie nur über eine Identifikationsnummer. Da Beiwe Sie nicht kennt, kann es nicht mit Ihrem Arzt kommunizieren, wenn Sie krank oder in Gefahr sind.\\n\\nBeiwe wurde von Dr. Jukka-Pekka \\\"JP\\\" Onnela an der Harvard School of Public Health konzipiert und entworfen. Die Software wurde von Zagaran, Inc. in Cambridge, Massachusetts entwickelt.</string>
+
+    <!-- Phone Numbers -->
+    <string name="phone_number_length_error">" Telefonnummern müssen genau %d Ziffern lang sein."</string>
+    <string name="enter_clinician_number">Sie müssen einen Wert für die Telefonnummer der Studienunterstützung eingeben</string>
+    <string name="enter_research_assitant_number">Sie müssen einen Wert für die Telefonnummer der technische Unterstützung eingeben</string>
+    <!-- Consent Form -->
+    <string name="title_activity_consent_form">Einverständnis zur Nutzung von Beiwe</string>
+    <string name="consentButton">Einwilligung zur Teilnahme am Forschungsprojekt</string>
+    <string name="doNotConsentButton">Abbrechen</string>
+    <string name="doNotConsentAlert">Sie haben angegeben, dass Sie mit den Bedingungen dieser Anwendung nicht einverstanden sind.  Wenn Sie auf „Ich verstehe“ klicken, wird die App beendet und Sie werden nicht an der Studie teilnehmen.  Wenn Sie auf \"Abbrechen\" klicken, wird die App nicht beendet und Sie können auf die Schaltfläche \"Ich stimme zu\" klicken, wodurch Sie in die Studie aufgenommen werden.</string>
+    <string name="i_understand_button_text">Ich verstehe</string>
+    <string name="default_consent_form_text">
+        The Consent Form\n
+        Goes\n
+        Here.
+    </string>
+
+    <!-- Survey Settings Keys -->
+    <string name="phone_number_length_min_error">Telefonnummern müssen mindestens %d Ziffern lang sein.</string>
+    <string name="phone_number_length_max_error">Telefonnummern müssen maximal %d Ziffern lang sein.</string>
+</resources>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -9,30 +9,30 @@
     <!-- Permissions Strings -->
     <string name="permissions_alert_title">"Voraussetzung zur Berechtigung : "</string>
     <string name="permission_normal_request_template">Für diese Studie benötigt Beiwe die Berechtigung zu %s. Bitte drücken Sie auf „Zulassen“ für die folgende Berechtigungsanfrage.</string>
-    <string name="permission_bumping_request_template">Damit die Anmeldung für die Studie gelingt, benötigt Beiwe die Berechtigung für %s. Diese Berechtigung scheint deaktiviert zu sein. Sie werden zu den Einstellungen der Beiwe-App weitergeleitet, damit Sie die Berechtigung manuell aktivieren können.</string>
+    <string name="permission_bumping_request_template">Damit die Anmeldung für die Studie gelingt, benötigt Beiwe die Berechtigung %s. Diese Berechtigung scheint deaktiviert zu sein. Sie werden zu den Einstellungen der Beiwe-App weitergeleitet, damit Sie die Berechtigung manuell aktivieren können.</string>
     <string name="permission_registration_read_sms_alert">Um sich für eine Studie anzumelden, benötigt Beiwe Zugang zu einigen Telefondiensten dieses Geräts. Bitte drücken Sie „Zulassen“, wenn Sie ein Menü sehen, in dem Berechtigungen für den Zugriff auf SMS angefordert werden. Abhängig vom Studientyp können Sie diese Berechtigung nach Abschluss der Registrierung in den Einstellungen der Beiwe-App deaktivieren.</string>
     <string name="permission_registration_actually_need_sms_alert">Beiwe benötigt SMS-Berechtigungen, um Sie für eine Studie anzumelden, aber diese Berechtigung scheint deaktiviert zu sein. Sie werden zu den Einstellungen der Beiwe-App weitergeleitet, damit Sie die SMS-Berechtigung manuell aktivieren können.</string>
     <string name="power_management_exception_alert">Diese Berechtigungsabfrage, die Sie gleich sehen werden, ist erforderlich, damit die Beiwe-App im Hintergrund ausgeführt werden kann.</string>
     <string name="cant_make_phone_call_alert_title">Beiwe kann keine Telefonate durchführen</string>
     <string name="cant_make_a_phone_call_permissions_alert">Damit Beiwe einen Telefonanruf durchführen kann, müssen Sie unter [Einstellungen] -> [Berechtigungen] und der Beiwe-App die Berechtigung \"Telefon\" erteilen.\\n\\n Oder Sie können die Telefon-App öffnen und den Anruf selbst tätigen.</string>
     <string name="go_to_settings_button">zu den Einstellungen gehen</string>
-    <string name="permission_access_fine_location">Ortungsdienste verwenden</string>
-    <string name="permission_access_network_state">Netzwerkeinstellungen anzeigen</string>
-    <string name="permission_access_wifi_state">WLAN-Verbindung anzeigen</string>
-    <string name="permission_read_sms">Ihre SMS-Nachrichten anzeigen</string>
-    <string name="permission_bluetooth">Bluetooth verwenden</string>
-    <string name="permission_bluetooth_admin">Bluetooth verwenden</string>
-    <string name="permission_call_phone">auf ihren Telefondienst zugreifen</string>
-    <string name="permission_internet">auf das Internet zugreifen</string>
-    <string name="permission_read_call_log">auf Ihren Telefondienst zugreifen</string>
-    <string name="permission_read_contacts">auf Ihre Kontakte zugreifen</string>
-    <string name="permission_read_phone_state">auf Ihren Telefondienst zugreifen</string>
-    <string name="permission_receive_boot_completed">App beim Hochfahren des Telefons starten</string>
-    <string name="permission_record_audio">auf Ihr Mikrofon zugreifen</string>
-    <string name="permission_access_coarse_location">Ortungsdienste verwenden</string>
-    <string name="permission_receive_mms">MMS-Nachrichten empfangen</string>
-    <string name="permission_receive_sms">SMS-Nachrichten empfangen</string>
-    <string name="permission_access_background_location">Standort verwenden: „Immer zulassen\“</string>
+    <string name="permission_access_fine_location">für den Zugriff auf die Ortungsdienste</string>
+    <string name="permission_access_network_state">für den Zugriff auf den Netzwerkstatus</string>
+    <string name="permission_access_wifi_state">für den Zugriff auf den WLAN-Status</string>
+    <string name="permission_read_sms">für den Zugriff auf die SMS-Nachrichten</string>
+    <string name="permission_bluetooth">für den Zugriff auf Bluetooth</string>
+    <string name="permission_bluetooth_admin">für den Zugriff auf Bluetooth</string>
+    <string name="permission_call_phone">"für den Zugriff auf den Telefondienst "</string>
+    <string name="permission_internet">"für den Zugriff auf das Internet "</string>
+    <string name="permission_read_call_log">"für den Zugriff auf den Telefondienst "</string>
+    <string name="permission_read_contacts">für den Zugriff auf die Kontakte</string>
+    <string name="permission_read_phone_state">für den Zugriff auf den Telefondienst</string>
+    <string name="permission_receive_boot_completed">beim Einschalten des Telefons zu starten</string>
+    <string name="permission_record_audio">"für den Zugriff auf den Mikrofon "</string>
+    <string name="permission_access_coarse_location">für den Zugriff auf die Ortungsdienste</string>
+    <string name="permission_receive_mms">"zum Empfang von MMS-Nachrichten "</string>
+    <string name="permission_receive_sms">"zum Empfang von SMS-Nachrichten "</string>
+    <string name="permission_access_background_location">Standort-Zugriff erlauben: „Immer zulassen\\“</string>
 
     <!-- API URLs -->
 

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -103,7 +103,7 @@
     <!-- Registration Activity Strings -->
     <string name="registration_welcome_message">Willkommen in der Beiwe-App</string>
     <string name="registration_server_url_label">Studien-URL</string>
-    <string name="registration_server_url_hint">Zum Beispiel www.eu.beiwe.org</string>
+    <string name="registration_server_url_hint">Zum Beispiel eu.beiwe.org</string>
     <string name="registration_user_id_label">Benutzername:</string>
     <string name="registration_user_id_hint">Benutzername</string>
     <string name="registration_temp_password_label">vorläufiges Passwort:</string>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -9,30 +9,30 @@
     <!-- Permissions Strings -->
     <string name="permissions_alert_title">Requisiti per le autorizzazioni:</string>
     <string name="permission_normal_request_template">Per questo studio Beiwe ha bisogno dell\'autorizzazione per %s. Per favore premi Consenti sulla seguente richiesta di autorizzazione</string>
-    <string name="permission_bumping_request_template">Per essere completamente arruolato in questo studio, Beiwe ha bisogno dell\'autorizzazione a %s. Sembra che tu abbia negato o rimosso questa autorizzazione. Beiwe ora ti indirizzerà alla sua pagina nelle impostazioni in modo che tu possa abilitarla manualmente.</string>
+    <string name="permission_bumping_request_template">Per essere completamente arruolato in questo studio, Beiwe ha bisogno dell\'autorizzazione a%s. Sembra che tu abbia negato o rimosso questa autorizzazione. Beiwe ora ti indirizzerà alla sua pagina nelle impostazioni in modo che tu possa abilitarla manualmente.</string>
     <string name="permission_registration_read_sms_alert">Per iscriversi a uno studio, Beiwe richiede l\'accesso ad alcuni servizi telefonici di questo dispositivo. Premi \\\"Consenti\\\" quando vedi un menu che richiede le autorizzazioni per accedere agli SMS. A seconda dei dettagli dello studio, puoi disabilitare questa autorizzazione nelle preferenze dell\'app Beiwe dopo che la registrazione è stata completata.</string>
     <string name="permission_registration_actually_need_sms_alert">Beiwe richiede autorizzazioni SMS per registrarsi a uno studio, ma sembra che tu le abbia negato l\'autorizzazione. Ti indirizzeremo alle impostazioni dell\'app Beiwe in modo che tu possa abilitare manualmente l\'accesso agli SMS.</string>
     <string name="power_management_exception_alert">La richiesta di autorizzazione che stai per visualizzare è necessaria per consentire a Beiwe di essere eseguita in background.</string>
     <string name="cant_make_phone_call_alert_title">Beiwe non può avviare telefonate</string>
     <string name="cant_make_a_phone_call_permissions_alert">Affinché Beiwe possa avviare una telefonata, devi andare su Impostazioni -> Autorizzazioni e concedere all\'app Beiwe l\'autorizzazione \'Telefono\'.\n\nOppure puoi aprire l\'app Telefono e fai tu stesso la telefonata.</string>
     <string name="go_to_settings_button">Vai a Impostazioni</string>
-    <string name="permission_access_fine_location">utilizza servizi di localizzazione</string>
-    <string name="permission_access_network_state">visualizza lo stato della tua rete</string>
-    <string name="permission_access_wifi_state">visualizza il tuo stato Wi-Fi</string>
-    <string name="permission_read_sms">visualizza i tuoi messaggi SMS</string>
-    <string name="permission_bluetooth">utilizza il Bluetooth</string>
-    <string name="permission_bluetooth_admin">utilizza il Bluetooth</string>
-    <string name="permission_call_phone">accedi al tuo servizio telefonico</string>
-    <string name="permission_internet">accedi ad Internet</string>
-    <string name="permission_read_call_log">accedi al tuo servizio telefonico</string>
-    <string name="permission_read_contacts">accedi ai tuoi contatti</string>
-    <string name="permission_read_phone_state">accedi al tuo servizio telefonico</string>
-    <string name="permission_receive_boot_completed">avvio all\'avvio</string>
-    <string name="permission_record_audio">accedi al tuo microfono</string>
-    <string name="permission_access_coarse_location">utilizza i servizi di localizzazione</string>
-    <string name="permission_receive_mms">ricevi messaggi MMS</string>
-    <string name="permission_receive_sms">ricevi messaggi SMS</string>
-    <string name="permission_access_background_location">utilizza l’opzione: \"Consenti sempre\"</string>
+    <string name="permission_access_fine_location"> utilizza servizi di localizzazione</string>
+    <string name="permission_access_network_state"> visualizza lo stato della tua rete</string>
+    <string name="permission_access_wifi_state"> visualizza il tuo stato Wi-Fi</string>
+    <string name="permission_read_sms"> visualizza i tuoi messaggi SMS</string>
+    <string name="permission_bluetooth"> utilizza il Bluetooth</string>
+    <string name="permission_bluetooth_admin"> utilizza il Bluetooth</string>
+    <string name="permission_call_phone"> accedi al tuo servizio telefonico</string>
+    <string name="permission_internet"> accedi ad Internet</string>
+    <string name="permission_read_call_log"> accedere al tuo servizio telefonico</string>
+    <string name="permission_read_contacts"> accedere ai tuoi contatti</string>
+    <string name="permission_read_phone_state"> accedi al tuo servizio telefonico</string>
+    <string name="permission_receive_boot_completed"> avvio all\'avvio</string>
+    <string name="permission_record_audio"> accedi al tuo microfono</string>
+    <string name="permission_access_coarse_location"> utilizza i servizi di localizzazione</string>
+    <string name="permission_receive_mms"> ricevere messaggi MMS</string>
+    <string name="permission_receive_sms"> ricevere messaggi SMS</string>
+    <string name="permission_access_background_location">d utilizzare l’opzione: \"Consenti sempre\"</string>
 
     <!-- API URLs -->
 
@@ -44,7 +44,7 @@
     <!-- Debug Menu Strings -->
 
     <!-- Error Messages -->
-    <string name="default_alert_title">Notare</string>
+    <string name="default_alert_title">Nota</string>
     <string name="alert_ok_button_text">OK</string>
     <string name="alert_cancel_button_text">Annulla</string>
     <string name="question_error_text">Se stai leggendo questo, qualcosa si è rotto. Si prega di contattare gli amministratori dello studio e di dire loro che c\'è un bug nel sondaggio!</string>
@@ -64,7 +64,7 @@
     <!-- Survey Activity Strings -->
     <string name="survey_next_button_text">Prossimo"</string>
     <string name="survey_submit_button">Invia questionario</string>
-    <string name="default_survey_submit_success_message">Grazie per aver completato il sondaggio. Un medico non vedrà immediatamente le tue risposte, quindi se hai bisogno di aiuto o stai pensando di farti del male, contatta il tuo medico. Puoi anche premere il pulsante \"Chiama il mio medico\".</string>
+    <string name="default_survey_submit_success_message">Grazie per aver completato il sondaggio. Un medico non vedrà immediatamente le tue risposte, quindi se hai bisogno di aiuto o stai pensando di farti del male, contatta il tuo medico. Puoi anche premere il pulsante \"Chiama il medico\".</string>
     <string name="survey_submit_error_message">Questionario non salvata</string>
     <string name="survey_loading_text" tools:ignore="TypographyEllipsis">Download delle domande aggiornate del questionario in corso…</string>
 
@@ -96,7 +96,7 @@
 <string name="title_activity_forgot_password">password dimenticata</string>
 <string name="forgot_password_title">Per favore contatta il personale dello studio e presenta il tuo ID paziente in modo che possano fornirti una password temporanea</string>
 <string name="forgot_password_instructions_text">Il tuo ID è \"%s\"; ricordati di identificarti con questo ID e non con il tuo nome.</string>
-<string name="forgot_password_call_button_text">Chiama il assistente ricerca</string>
+<string name="forgot_password_call_button_text">Chiama assistente di ricerca</string>
 <string name="forgot_password_temporary_password_caption">Password temporanea:</string>
 
     <!-- Registration Activity Strings -->
@@ -143,7 +143,7 @@
 <string name="title_activity_graph">Risposte ai questionari precedent</string>
 <string name="permasurvey">permasurvey</string>
 <string name="perm_survey">Questionario</string>
-<string name="permaaudiosurvey">Questionario audio</string>
+<string name="permaaudiosurvey">Registrazione audio</string>
 
     <!-- Recording Activity -->
 <string name="record_activity_default_message">We would like to know how your day is going.  When you are ready, please press \"Record\" and speak for about 2 minutes.  Press \"Stop\" when you are finished. The recording will stop automatically after 4 minutes. Remember, researchers will not review and analyze your data until the end of the study, so if you are ill or in danger and need to speak with your clinician, press the \"Call My Clinician\" button.</string>
@@ -161,7 +161,7 @@
 <string name="survey_notification_app_name">Beiwe</string>
 <string name="new_android_survey_notification_ticker">È disponibile un nuovo questionario da compilare</string>
 <string name="new_android_survey_notification_details">Si prega di compilare questo sondaggio.</string>
-<string name="new_audio_survey_notification_ticker">È disponibile un nuovo questionario audio a cui rispondere</string>
+<string name="new_audio_survey_notification_ticker">È disponibile un nuovo registrazione audio a cui rispondere</string>
 <string name="new_audio_survey_notification_details">Registra</string>
 
     <!-- Notification Action Pointers -->
@@ -172,12 +172,12 @@
 <string name="menu_sign_out">Logout</string>
 <string name="menu_change_password">Cambia password</string>
 <string name="menu_about">Informazioni su questa app</string>
-<string name="call_research_assistant">Chiama il assistente ricerca</string>
+<string name="call_research_assistant">Chiama assistente di ricerca</string>
 <string name="view_survey_answers">"Visualizza le risposte ai questionari "</string>
 
     <!-- About Page -->
 <string name="title_activity_about">Informazioni su Beiwe</string>
-<string name="default_about_page_text">Beiwe è un\'applicazione che funziona sul tuo cellulare e aiuta i ricercatori a raccogliere informazioni sulla tua salute e sui tuoi comportamenti. Ti chiede di compilare brevi sondaggi e di registrare la tua voce una volta al giorno. Beiwe raccoglie continuamente informazioni sulla tua posizione (usando il GPS del tuo telefono) e su quanto ti muovi (usando l\'accelerometro del tuo telefono). Monitora anche quanto usi il telefono per chiamare e inviare SMS e tiene traccia delle diverse persone con cui comunichi. È importante sottolineare che Beiwe non registra i nomi o i numeri di telefono delle persone con cui comunichi. Sebbene possa dire se chiami la stessa persona più di una volta, non sa chi sia quella persona. Beiwe non registra il contenuto dei tuoi messaggi di testo o delle tue telefonate. Tiene anche traccia delle diverse reti Wi-Fi nella tua zona, ma i nomi di tali reti vengono sostituiti con codici casuali. Infine, Beiwe può dire se sei vicino a un altro telefono che esegue anche questa applicazione.\n\nSebbene Beiwe raccolga una grande quantità di dati, tutti questi dati vengono elaborati per proteggere la tua privacy. Ciò significa che l\'applicazione non conosce il tuo nome, il tuo numero di telefono o qualsiasi altra cosa che possa identificarti. Beiwe ti conosce solo tramite un numero di identificazione. Poiché Beiwe non sa chi sei, non può comunicare con il tuo medico se sei malato o in pericolo. I ricercatori non esamineranno i dati raccolti da Beiwe fino alla fine dello studio. Per facilitare la connessione con il medico, nella parte superiore di ogni pagina viene visualizzato il pulsante \"Chiama il mio medico\". Affinché il pulsante funzioni, devi inserire il numero di telefono del tuo medico in Beiwe. Puoi cambiarlo tutte le volte che vuoi.\n\nBeiwe è stato concepito e progettato dal Dr. Jukka-Pekka \"JP\" Onnela presso la Harvard School of Public Health. Il software è stato creato da Zagaran, Inc., a Cambridge, Massachusetts.</string>
+<string name="default_about_page_text">Beiwe è un\'applicazione che funziona sul tuo cellulare e aiuta i ricercatori a raccogliere informazioni sulla tua salute e sui tuoi comportamenti. Ti chiede di compilare brevi sondaggi e di registrare la tua voce una volta al giorno. Beiwe raccoglie continuamente informazioni sulla tua posizione (usando il GPS del tuo telefono) e su quanto ti muovi (usando l\'accelerometro del tuo telefono). Monitora anche quanto usi il telefono per chiamare e inviare SMS e tiene traccia delle diverse persone con cui comunichi. È importante sottolineare che Beiwe non registra i nomi o i numeri di telefono delle persone con cui comunichi. Sebbene possa dire se chiami la stessa persona più di una volta, non sa chi sia quella persona. Beiwe non registra il contenuto dei tuoi messaggi di testo o delle tue telefonate. Tiene anche traccia delle diverse reti Wi-Fi nella tua zona, ma i nomi di tali reti vengono sostituiti con codici casuali. Infine, Beiwe può dire se sei vicino a un altro telefono che esegue anche questa applicazione.\n\nSebbene Beiwe raccolga una grande quantità di dati, tutti questi dati vengono elaborati per proteggere la tua privacy. Ciò significa che l\'applicazione non conosce il tuo nome, il tuo numero di telefono o qualsiasi altra cosa che possa identificarti. Beiwe ti conosce solo tramite un numero di identificazione. Poiché Beiwe non sa chi sei, non può comunicare con il tuo medico se sei malato o in pericolo. I ricercatori non esamineranno i dati raccolti da Beiwe fino alla fine dello studio. Per facilitare la connessione con il medico, nella parte superiore di ogni pagina viene visualizzato il pulsante \"Chiama il medico\". Affinché il pulsante funzioni, devi inserire il numero di telefono del tuo medico in Beiwe. Puoi cambiarlo tutte le volte che vuoi.\n\nBeiwe è stato concepito e progettato dal Dr. Jukka-Pekka \"JP\" Onnela presso la Harvard School of Public Health. Il software è stato creato da Zagaran, Inc., a Cambridge, Massachusetts.</string>
 
     <!-- Phone Numbers -->
 <string name="phone_number_length_error">I numeri di telefono devono contenere esattamente %d cifre.</string>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -22,13 +22,13 @@
     <string name="permission_read_sms">a visualizza i tuoi messaggi SMS</string>
     <string name="permission_bluetooth">a utilizza il Bluetooth</string>
     <string name="permission_bluetooth_admin">a utilizza il Bluetooth</string>
-    <string name="permission_call_phone">a accedere al tuo servizio telefonico</string>
+    <string name="permission_call_phone">ad accedere al tuo servizio telefonico</string>
     <string name="permission_internet">a accedere ad Internet</string>
-    <string name="permission_read_call_log">a accedere al tuo servizio telefonico</string>
-    <string name="permission_read_contacts">a accedere ai tuoi contatti</string>
-    <string name="permission_read_phone_state">a accedere al tuo servizio telefonico</string>
+    <string name="permission_read_call_log">ad accedere al tuo servizio telefonico</string>
+    <string name="permission_read_contacts">ad accedere ai tuoi contatti</string>
+    <string name="permission_read_phone_state">ad accedere al tuo servizio telefonico</string>
     <string name="permission_receive_boot_completed">a avvio all\'avvio</string>
-    <string name="permission_record_audio">a accedere al tuo microfono</string>
+    <string name="permission_record_audio">ad accedere al tuo microfono</string>
     <string name="permission_access_coarse_location">a utilizza i servizi di localizzazione</string>
     <string name="permission_receive_mms">a ricevere messaggi MMS</string>
     <string name="permission_receive_sms">a ricevere messaggi SMS</string>
@@ -160,7 +160,7 @@
     <!-- Notifications -->
 <string name="survey_notification_app_name">Beiwe</string>
 <string name="new_android_survey_notification_ticker">È disponibile un nuovo questionario da compilare</string>
-<string name="new_android_survey_notification_details">Si prega di compilare questo sondaggio.</string>
+<string name="new_android_survey_notification_details">Si prega di compilare questo questionario.</string>
 <string name="new_audio_survey_notification_ticker">È disponibile un nuovo registrazione audio a cui rispondere</string>
 <string name="new_audio_survey_notification_details">Registra</string>
 

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -71,7 +71,7 @@
     <!-- Login Activity Strings -->
     <string name="login_page_for_app">Accedi al tuo studio</string>
     <string name="login_activity_please_enter_password">Password:</string>
-    <string name="incorrect_user_wwwpass_combo">La password è stata inserita in modo errato</string>
+    <string name="incorrect_user_pass_combo">La password è stata inserita in modo errato</string>
     <string name="title_activity_register">Registrati</string>
     <string name="title_activity_login">Login</string>
     <string name="title_activity_login_string">Login</string>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -1,0 +1,202 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <!-- Reference strings in Java code using a line like this:
+    appContext.getResources().getString(R.string.name_of_string) -->
+
+    <!-- General Strings -->
+    <string name="action_settings">Impostazioni</string>
+	
+    <!-- Permissions Strings -->
+    <string name="permissions_alert_title">Requisiti per le autorizzazioni:</string>
+    <string name="permission_normal_request_template">Per questo studio Beiwe ha bisogno dell\'autorizzazione per %s. Per favore premi Consenti sulla seguente richiesta di autorizzazione</string>
+    <string name="permission_bumping_request_template">Per essere completamente arruolato in questo studio, Beiwe ha bisogno dell\'autorizzazione a %s. Sembra che tu abbia negato o rimosso questa autorizzazione. Beiwe ora ti indirizzerà alla sua pagina nelle impostazioni in modo che tu possa abilitarla manualmente.</string>
+    <string name="permission_registration_read_sms_alert">Per iscriversi a uno studio, Beiwe richiede l\'accesso ad alcuni servizi telefonici di questo dispositivo. Premi \\\"Consenti\\\" quando vedi un menu che richiede le autorizzazioni per accedere agli SMS. A seconda dei dettagli dello studio, puoi disabilitare questa autorizzazione nelle preferenze dell\'app Beiwe dopo che la registrazione è stata completata.</string>
+    <string name="permission_registration_actually_need_sms_alert">Beiwe richiede autorizzazioni SMS per registrarsi a uno studio, ma sembra che tu le abbia negato l\'autorizzazione. Ti indirizzeremo alle impostazioni dell\'app Beiwe in modo che tu possa abilitare manualmente l\'accesso agli SMS.</string>
+    <string name="power_management_exception_alert">La richiesta di autorizzazione che stai per visualizzare è necessaria per consentire a Beiwe di essere eseguita in background.</string>
+    <string name="cant_make_phone_call_alert_title">Beiwe non può avviare telefonate</string>
+    <string name="cant_make_a_phone_call_permissions_alert">Affinché Beiwe possa avviare una telefonata, devi andare su Impostazioni -> Autorizzazioni e concedere all\'app Beiwe l\'autorizzazione \'Telefono\'.\n\nOppure puoi aprire l\'app Telefono e fai tu stesso la telefonata.</string>
+    <string name="go_to_settings_button">Vai a Impostazioni</string>
+    <string name="permission_access_fine_location">utilizza servizi di localizzazione</string>
+    <string name="permission_access_network_state">visualizza lo stato della tua rete</string>
+    <string name="permission_access_wifi_state">visualizza il tuo stato Wi-Fi</string>
+    <string name="permission_read_sms">visualizza i tuoi messaggi SMS</string>
+    <string name="permission_bluetooth">utilizza il Bluetooth</string>
+    <string name="permission_bluetooth_admin">utilizza il Bluetooth</string>
+    <string name="permission_call_phone">accedi al tuo servizio telefonico</string>
+    <string name="permission_internet">accedi ad Internet</string>
+    <string name="permission_read_call_log">accedi al tuo servizio telefonico</string>
+    <string name="permission_read_contacts">accedi ai tuoi contatti</string>
+    <string name="permission_read_phone_state">accedi al tuo servizio telefonico</string>
+    <string name="permission_receive_boot_completed">avvio all\'avvio</string>
+    <string name="permission_record_audio">accedi al tuo microfono</string>
+    <string name="permission_access_coarse_location">utilizza i servizi di localizzazione</string>
+    <string name="permission_receive_mms">ricevi messaggi MMS</string>
+    <string name="permission_receive_sms">ricevi messaggi SMS</string>
+    <string name="permission_access_background_location">utilizza l’opzione: \"Consenti sempre\"</string>
+
+    <!-- API URLs -->
+
+    <!-- Recording Options Strings -->
+    <string name="title_activity_audio_recorder">Registra</string>
+    <string name="button_play">Ascolta audio</string>
+    <string name="button_record">Registra</string>
+
+    <!-- Debug Menu Strings -->
+
+    <!-- Error Messages -->
+    <string name="default_alert_title">Notare</string>
+    <string name="alert_ok_button_text">OK</string>
+    <string name="alert_cancel_button_text">Annulla</string>
+    <string name="question_error_text">Se stai leggendo questo, qualcosa si è rotto. Si prega di contattare gli amministratori dello studio e di dire loro che c\'è un bug nel sondaggio!</string>
+    <string name="invalid_device">Questo dispositivo non soddisfa le specifiche minime per questa app. Per evitare problemi derivanti da ciò, disinstallare l\'app.</string>
+    <string name="invalid_encryption_key">Ricevuta una chiave di crittografia non valida, contattare l\'amministratore di Beiwe</string>
+    <string name="http_message_200">OK</string>
+    <string name="http_message_1">Qualcuno ha configurato male il server! Si prega di contattare il personale di ricerca.</string>
+    <string name="http_message_400">Non è stato possibile registrare il dispositivo con questo account. Contatta il personale dello studio.</string>
+    <string name="http_message_403_during_registration">L\'URL, l\'ID paziente o la password inseriti non sono corretti.</string>
+    <string name="http_message_403_wrong_password">La password attuale è stata inserita in modo errato.</string>
+    <string name="http_message_403_wrong_password_forgot_password_page">La password temporanea è stata inserita in modo errato</string>
+    <string name="http_message_405">L\'ID paziente che stai utilizzando è già stato registrato. Si prega di confermare l\'ID paziente con il personale dello studio per completare la registrazione.</string>
+    <string name="http_message_internet_disconnected">Sembra che tu non sia connesso a Internet: connettiti a Internet e riprova.</string>
+    <string name="http_message_server_not_found">Si prega di confermare che l\'URL sia corretto. Beiwe non è stata in grado di connettersi al server.</string>
+    <string name="http_message_unknown_response_code">Si è verificato un errore sconosciuto in Beiwe.</string>
+
+    <!-- Survey Activity Strings -->
+    <string name="survey_next_button_text">Prossimo"</string>
+    <string name="survey_submit_button">Invia questionario</string>
+    <string name="default_survey_submit_success_message">Grazie per aver completato il sondaggio. Un medico non vedrà immediatamente le tue risposte, quindi se hai bisogno di aiuto o stai pensando di farti del male, contatta il tuo medico. Puoi anche premere il pulsante \"Chiama il mio medico\".</string>
+    <string name="survey_submit_error_message">Questionario non salvata</string>
+    <string name="survey_loading_text" tools:ignore="TypographyEllipsis">Download delle domande aggiornate del questionario in corso…</string>
+
+    <!-- Login Activity Strings -->
+    <string name="login_page_for_app">Accedi al tuo studio</string>
+    <string name="login_activity_please_enter_password">Password:</string>
+    <string name="incorrect_user_pass_combo">La password è stata inserita in modo errato</string>
+    <string name="title_activity_register">Registrati</string>
+    <string name="title_activity_login">Login</string>
+    <string name="title_activity_login_string">Login</string>
+    <string name="login_activity_welcoming_message">Accedi al tuo studio</string>
+    <string name="user_id_system_mismatch">l\'ID paziente non sono corretti.</string>
+    <string name="password_system_mismatch">l\'ID paziente o la password inseriti non sono corretti.</string>
+
+    <!-- Reset Password Activity Strings -->
+    <string name="title_activity_reset_password">Cambia password</string>
+<string name="reset_password_title">Cambia password</string>
+<string name="reset_password_current_password_caption">Password attuale:</string>
+<string name="reset_password_new_password_caption">Nuova password:</string>
+<string name="reset_password_confirm_new_password_caption">Conferma nuova password:</string>
+<string name="reset_password_submit">Cambia password</string>
+<string name="reset_password_error_alert_title">Aggiornamento password fallito</string>
+<string name="invalid_old_password">La password attuale è stata inserita in modo errato</string>
+<string name="pass_reset_complete">La tua password è stata modificata con successo</string>
+<string name="password_mismatch">La nuova password non corrisponde Conferma nuova password.</string>
+<string name="password_too_short">La tua nuova password deve contenere almeno %d caratteri</string>
+
+    <!-- Forgot Password Activity Strings -->
+<string name="title_activity_forgot_password">password dimenticata</string>
+<string name="forgot_password_title">Per favore contatta il personale dello studio e presenta il tuo ID paziente in modo che possano fornirti una password temporanea</string>
+<string name="forgot_password_instructions_text">Il tuo ID è \"%s\"; ricordati di identificarti con questo ID e non con il tuo nome.</string>
+<string name="forgot_password_call_button_text">Chiama il assistente ricerca</string>
+<string name="forgot_password_temporary_password_caption">Password temporanea:</string>
+
+    <!-- Registration Activity Strings -->
+<string name="registration_welcome_message">Benvenuto nello Studio</string>
+<string name="registration_server_url_label">URL dello studio:</string>
+<string name="registration_server_url_hint">Ad esempio, www.eu.beiwe.org</string>
+<string name="registration_user_id_label">ID paziente:</string>
+<string name="registration_user_id_hint">ID paziente</string>
+<string name="registration_temp_password_label">Password temporanea:</string>
+<string name="registration_temp_password_hint">Password temporanea</string>
+<string name="registration_new_password_label">Nuova password:</string>
+<string name="registration_new_password_hint">Lunghezza minima 6 caratteri</string>
+<string name="registration_confirm_new_password_label">Conferma password:</string>
+<string name="registration_confirm_new_password_hint">Lunghezza minima 6 caratteri</string>
+<string name="registration_replacement_password_hint">Lunghezza minima %d caratteri</string>
+<string name="registration_submit">Registrati</string>
+<string name="title_activity_loading">Caricamento di Beiwe</string>
+<string name="empty_temp_password">Per favore inserisci la password temporanea che ti è stata data al momento della registrazione.</string>
+<string name="url_too_short">Per favore inserisci l\'URL dello studio</string>
+<string name="invalid_user_id">Per favore inserisci il tuo ID paziente</string>
+<string name="invalid_password">La password inseriti non sono corretti.</string>
+<string name="couldnt_register">Registrazione fallita</string>
+
+    <!-- Phone Numbers -->
+<string name="title_activity_phone_number_entry">Numeri di telefono</string>
+<string name="number_entry_top_message">Numeri di telefono</string>
+<string name="number_entry_button">Inserisci i numeri di telefono</string>
+<string name="phone_number_entry_your_clinician_label">Telefono ricercatore primario</string>
+<string name="phone_number_entry_your_clinician_hint"> </string>
+<string name="phone_number_entry_research_assistant_label">Telefono assistente ricerca:</string>
+<string name="phone_number_entry_research_assistant_hint"> </string>
+
+    <!-- Loading Activity Strings -->
+<string name="loading_activity_loading_message" tools:ignore="TypographyEllipsis">Caricamento in corso...</string>
+<string name="survey_notification_title_template">Questionario: %s</string>
+<string name="action_share">Condividere</string>
+<string name="action_reply">Rispondere</string>
+
+    <!-- Main menu strings -->
+<string name="title_activity_main_menu">Schermata principale di Beiwe</string>
+<string name="main_menu_top_message">Benvenuto in Beiwe!</string>
+<string name="main_menu_view_graph">"Visualizza le risposte ai questionari in forma di grafico "</string>
+<string name="default_call_clinician_text">Chiama il medico</string>
+<string name="title_activity_graph">Risposte ai questionari precedent</string>
+<string name="permasurvey">permasurvey</string>
+<string name="perm_survey">Questionario</string>
+<string name="permaaudiosurvey">Questionario audio</string>
+
+    <!-- Recording Activity -->
+<string name="record_activity_default_message">We would like to know how your day is going.  When you are ready, please press \"Record\" and speak for about 2 minutes.  Press \"Stop\" when you are finished. The recording will stop automatically after 4 minutes. Remember, researchers will not review and analyze your data until the end of the study, so if you are ill or in danger and need to speak with your clinician, press the \"Call My Clinician\" button.</string>
+<string name="record_activity_button">Registra</string>
+<string name="record_activity_playback">Ascolta audio</string>
+<string name="play_button_text">Ascolta audio</string>
+<string name="play_button_stop_text">Stop</string>
+<string name="record_button_text">Registra</string>
+<string name="record_button_stop_text">Stop</string>
+<string name="done_button_text">Salva</string>
+<string name="timeout_msg_1st_half">"La registrazione vocale non può durare più di "</string>
+<string name="timeout_msg_2nd_half">minuti, perciò la registrazione è stata automaticamente interrotta e salvata</string>
+
+    <!-- Notifications -->
+<string name="survey_notification_app_name">Beiwe</string>
+<string name="new_android_survey_notification_ticker">È disponibile un nuovo questionario da compilare</string>
+<string name="new_android_survey_notification_details">Si prega di compilare questo sondaggio.</string>
+<string name="new_audio_survey_notification_ticker">È disponibile un nuovo questionario audio a cui rispondere</string>
+<string name="new_audio_survey_notification_details">Registra</string>
+
+    <!-- Notification Action Pointers -->
+
+    <!-- Timer Action Strings -->
+
+    <!-- Menu Items -->
+<string name="menu_sign_out">Logout</string>
+<string name="menu_change_password">Cambia password</string>
+<string name="menu_about">Informazioni su questa app</string>
+<string name="call_research_assistant">Chiama il assistente ricerca</string>
+<string name="view_survey_answers">"Visualizza le risposte ai questionari "</string>
+
+    <!-- About Page -->
+<string name="title_activity_about">Informazioni su Beiwe</string>
+<string name="default_about_page_text">Beiwe è un\'applicazione che funziona sul tuo cellulare e aiuta i ricercatori a raccogliere informazioni sulla tua salute e sui tuoi comportamenti. Ti chiede di compilare brevi sondaggi e di registrare la tua voce una volta al giorno. Beiwe raccoglie continuamente informazioni sulla tua posizione (usando il GPS del tuo telefono) e su quanto ti muovi (usando l\'accelerometro del tuo telefono). Monitora anche quanto usi il telefono per chiamare e inviare SMS e tiene traccia delle diverse persone con cui comunichi. È importante sottolineare che Beiwe non registra i nomi o i numeri di telefono delle persone con cui comunichi. Sebbene possa dire se chiami la stessa persona più di una volta, non sa chi sia quella persona. Beiwe non registra il contenuto dei tuoi messaggi di testo o delle tue telefonate. Tiene anche traccia delle diverse reti Wi-Fi nella tua zona, ma i nomi di tali reti vengono sostituiti con codici casuali. Infine, Beiwe può dire se sei vicino a un altro telefono che esegue anche questa applicazione.\n\nSebbene Beiwe raccolga una grande quantità di dati, tutti questi dati vengono elaborati per proteggere la tua privacy. Ciò significa che l\'applicazione non conosce il tuo nome, il tuo numero di telefono o qualsiasi altra cosa che possa identificarti. Beiwe ti conosce solo tramite un numero di identificazione. Poiché Beiwe non sa chi sei, non può comunicare con il tuo medico se sei malato o in pericolo. I ricercatori non esamineranno i dati raccolti da Beiwe fino alla fine dello studio. Per facilitare la connessione con il medico, nella parte superiore di ogni pagina viene visualizzato il pulsante \"Chiama il mio medico\". Affinché il pulsante funzioni, devi inserire il numero di telefono del tuo medico in Beiwe. Puoi cambiarlo tutte le volte che vuoi.\n\nBeiwe è stato concepito e progettato dal Dr. Jukka-Pekka \"JP\" Onnela presso la Harvard School of Public Health. Il software è stato creato da Zagaran, Inc., a Cambridge, Massachusetts.</string>
+
+    <!-- Phone Numbers -->
+<string name="phone_number_length_error">I numeri di telefono devono contenere esattamente %d cifre.</string>
+<string name="enter_clinician_number">È necessario immettere un valore per il numero di telefono del medico </string>
+<string name="enter_research_assitant_number">È necessario immettere un valore per il numero di telefono dell\'assistente di ricerca </string>
+    <!-- Consent Form -->
+<string name="title_activity_consent_form">Consenso per utilizzare Beiwe</string>
+<string name="consentButton">Consenti</string>
+<string name="doNotConsentButton">Annulla</string>
+<string name="doNotConsentAlert">Hai indicato di non acconsentire ai termini di questa applicazione. Se premi \"Ho capito\" l\'app uscirà e non verrai iscritto allo studio. Se premi \"Annulla\" l\'app non uscirà e potrai premere il pulsante \"Acconsento\", che ti iscriverà allo studio.</string>
+<string name="i_understand_button_text">Capisco</string>
+<string name="default_consent_form_text">
+         Il modulo di consenso\n
+         Va\n
+         Qui.
+    </string>
+    <string name="title_activity_survey">Questionario</string>
+    <string name="phone_number_length_min_error">I numeri di telefono devono contenere minima %d cifre.</string>
+    <string name="phone_number_length_max_error">I numeri di telefono devono contenere massimo %d cifre.</string>
+
+    <!-- Survey Settings Keys -->
+</resources>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -8,31 +8,31 @@
 	
     <!-- Permissions Strings -->
     <string name="permissions_alert_title">Requisiti per le autorizzazioni:</string>
-    <string name="permission_normal_request_template">Per questo studio Beiwe ha bisogno dell\'autorizzazione per %s. Per favore premi Consenti sulla seguente richiesta di autorizzazione</string>
-    <string name="permission_bumping_request_template">Per essere completamente arruolato in questo studio, Beiwe ha bisogno dell\'autorizzazione a%s. Sembra che tu abbia negato o rimosso questa autorizzazione. Beiwe ora ti indirizzerà alla sua pagina nelle impostazioni in modo che tu possa abilitarla manualmente.</string>
+    <string name="permission_normal_request_template">Per questo studio Beiwe ha bisogno dell\'autorizzazione %s. Per favore premi Consenti sulla seguente richiesta di autorizzazione</string>
+    <string name="permission_bumping_request_template">Per essere completamente arruolato in questo studio, Beiwe ha bisogno dell\'autorizzazione %s. Sembra che tu abbia negato o rimosso questa autorizzazione. Beiwe ora ti indirizzerà alla sua pagina nelle impostazioni in modo che tu possa abilitarla manualmente.</string>
     <string name="permission_registration_read_sms_alert">Per iscriversi a uno studio, Beiwe richiede l\'accesso ad alcuni servizi telefonici di questo dispositivo. Premi \\\"Consenti\\\" quando vedi un menu che richiede le autorizzazioni per accedere agli SMS. A seconda dei dettagli dello studio, puoi disabilitare questa autorizzazione nelle preferenze dell\'app Beiwe dopo che la registrazione è stata completata.</string>
     <string name="permission_registration_actually_need_sms_alert">Beiwe richiede autorizzazioni SMS per registrarsi a uno studio, ma sembra che tu le abbia negato l\'autorizzazione. Ti indirizzeremo alle impostazioni dell\'app Beiwe in modo che tu possa abilitare manualmente l\'accesso agli SMS.</string>
     <string name="power_management_exception_alert">La richiesta di autorizzazione che stai per visualizzare è necessaria per consentire a Beiwe di essere eseguita in background.</string>
     <string name="cant_make_phone_call_alert_title">Beiwe non può avviare telefonate</string>
     <string name="cant_make_a_phone_call_permissions_alert">Affinché Beiwe possa avviare una telefonata, devi andare su Impostazioni -> Autorizzazioni e concedere all\'app Beiwe l\'autorizzazione \'Telefono\'.\n\nOppure puoi aprire l\'app Telefono e fai tu stesso la telefonata.</string>
     <string name="go_to_settings_button">Vai a Impostazioni</string>
-    <string name="permission_access_fine_location"> utilizza servizi di localizzazione</string>
-    <string name="permission_access_network_state"> visualizza lo stato della tua rete</string>
-    <string name="permission_access_wifi_state"> visualizza il tuo stato Wi-Fi</string>
-    <string name="permission_read_sms"> visualizza i tuoi messaggi SMS</string>
-    <string name="permission_bluetooth"> utilizza il Bluetooth</string>
-    <string name="permission_bluetooth_admin"> utilizza il Bluetooth</string>
-    <string name="permission_call_phone"> accedi al tuo servizio telefonico</string>
-    <string name="permission_internet"> accedi ad Internet</string>
-    <string name="permission_read_call_log"> accedere al tuo servizio telefonico</string>
-    <string name="permission_read_contacts"> accedere ai tuoi contatti</string>
-    <string name="permission_read_phone_state"> accedi al tuo servizio telefonico</string>
-    <string name="permission_receive_boot_completed"> avvio all\'avvio</string>
-    <string name="permission_record_audio"> accedi al tuo microfono</string>
-    <string name="permission_access_coarse_location"> utilizza i servizi di localizzazione</string>
-    <string name="permission_receive_mms"> ricevere messaggi MMS</string>
-    <string name="permission_receive_sms"> ricevere messaggi SMS</string>
-    <string name="permission_access_background_location">d utilizzare l’opzione: \"Consenti sempre\"</string>
+    <string name="permission_access_fine_location">ad utilizzare servizi di localizzazione</string>
+    <string name="permission_access_network_state">a visualizza lo stato della tua rete</string>
+    <string name="permission_access_wifi_state">a visualizza il tuo stato Wi-Fi</string>
+    <string name="permission_read_sms">a visualizza i tuoi messaggi SMS</string>
+    <string name="permission_bluetooth">a utilizza il Bluetooth</string>
+    <string name="permission_bluetooth_admin">a utilizza il Bluetooth</string>
+    <string name="permission_call_phone">a accedere al tuo servizio telefonico</string>
+    <string name="permission_internet">a accedere ad Internet</string>
+    <string name="permission_read_call_log">a accedere al tuo servizio telefonico</string>
+    <string name="permission_read_contacts">a accedere ai tuoi contatti</string>
+    <string name="permission_read_phone_state">a accedere al tuo servizio telefonico</string>
+    <string name="permission_receive_boot_completed">a avvio all\'avvio</string>
+    <string name="permission_record_audio">a accedere al tuo microfono</string>
+    <string name="permission_access_coarse_location">a utilizza i servizi di localizzazione</string>
+    <string name="permission_receive_mms">a ricevere messaggi MMS</string>
+    <string name="permission_receive_sms">a ricevere messaggi SMS</string>
+    <string name="permission_access_background_location">ad utilizzare l’opzione: \"Consenti sempre\"</string>
 
     <!-- API URLs -->
 

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -71,7 +71,7 @@
     <!-- Login Activity Strings -->
     <string name="login_page_for_app">Accedi al tuo studio</string>
     <string name="login_activity_please_enter_password">Password:</string>
-    <string name="incorrect_user_pass_combo">La password è stata inserita in modo errato</string>
+    <string name="incorrect_user_wwwpass_combo">La password è stata inserita in modo errato</string>
     <string name="title_activity_register">Registrati</string>
     <string name="title_activity_login">Login</string>
     <string name="title_activity_login_string">Login</string>
@@ -102,7 +102,7 @@
     <!-- Registration Activity Strings -->
 <string name="registration_welcome_message">Benvenuto nello Studio</string>
 <string name="registration_server_url_label">URL dello studio:</string>
-<string name="registration_server_url_hint">Ad esempio, www.eu.beiwe.org</string>
+<string name="registration_server_url_hint">Ad esempio, eu.beiwe.org</string>
 <string name="registration_user_id_label">ID paziente:</string>
 <string name="registration_user_id_hint">ID paziente</string>
 <string name="registration_temp_password_label">Password temporanea:</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -234,4 +234,6 @@
     <string name="randomizeWithMemory" translatable="false">randomize_with_memory</string>
     <string name="numberQuestions" translatable="false">number_of_random_questions</string>
     <string name="triggeredSurvey" translatable="false">trigger_on_first_download</string>
+    <string name="phone_number_length_min_error">Error: Phone Numbers must be at least %d digits long.</string>
+    <string name="phone_number_length_max_error">Error: Phone numbers must be at most %d characters long</string>
 </resources>


### PR DESCRIPTION
This PR sets a min and max number for phone numbers rather than requiring them to be at least 15 characters long. 

I also added localization files for German and Italian.

The app worked correctly on the Android emulator on my machine, and researchers haven't had issues with the screenshots I've sent them. 