### PR TITLE
Increase Target SDK from 29 to 30

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -63,19 +63,19 @@ android {
             dimension "version"
             manifestPlaceholders = [appName: "Beiwe"]
             buildConfigField("boolean", "CUSTOMIZABLE_SERVER_URL", "false")
-            buildConfigField("boolean", "READ_TEXTS_CALLS_BACKGROUND_LOCATION", 'true')
+            buildConfigField("boolean", "READ_SMS_AND_PHONE_CALL_STATS", 'true')
         }
         googlePlayStore {
             dimension "version"
             manifestPlaceholders = [appName: "Beiwe2"]
             buildConfigField("boolean", "CUSTOMIZABLE_SERVER_URL", 'true')
-            buildConfigField("boolean", "READ_TEXTS_CALLS_BACKGROUND_LOCATION", 'false')
+            buildConfigField("boolean", "READ_SMS_AND_PHONE_CALL_STATS", 'false')
         }
         commStatsCustomUrl {
             dimension "version"
             manifestPlaceholders = [appName: "Beiwe"]
             buildConfigField("boolean", "CUSTOMIZABLE_SERVER_URL", "true")
-            buildConfigField("boolean", "READ_TEXTS_CALLS_BACKGROUND_LOCATION", 'true')
+            buildConfigField("boolean", "READ_SMS_AND_PHONE_CALL_STATS", 'true')
         }
     }
     useLibrary "org.apache.http.legacy"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,7 +24,7 @@ android {
         applicationId "org.beiwe.app"
         minSdkVersion 16
         multiDexEnabled true
-        targetSdkVersion 29
+        targetSdkVersion 30
         versionCode 57       //TODO: update this Beiwe version code for new releases
         versionName '3.1.3'  //TODO: update this Beiwe version number for new releases
         setProperty("archivesBaseName", "Beiwe-$versionName")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,7 +26,6 @@
 	<!-- Permission used in android 6+ for being whitelisted for app standby -->
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
     <!-- as of the android 6 compatibility update, Beiwe no longer supports installation onto external media -->
-    <!-- <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" /> -->
     <!-- Power management and monitoring, not sure where this would be used... -->
     <uses-permission android:name="android.permission.BATTERY_STATS" />
     

--- a/app/src/main/java/org/beiwe/app/PermissionHandler.java
+++ b/app/src/main/java/org/beiwe/app/PermissionHandler.java
@@ -71,7 +71,6 @@ public class PermissionHandler {
 	 *  We will check for microphone recording as a special condition on the audio recording screen. */
 	public static Boolean checkAccessCoarseLocation(Context context) { if ( android.os.Build.VERSION.SDK_INT >= 23) { return context.checkSelfPermission(Manifest.permission.ACCESS_COARSE_LOCATION) == PERMISSION_GRANTED; } else { return true; } }
 	public static Boolean checkAccessFineLocation(Context context) { if ( android.os.Build.VERSION.SDK_INT >= 23) { return context.checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION) == PERMISSION_GRANTED; } else { return true; } }
-	public static Boolean checkAccessBackgroundLocation(Context context) { if ( android.os.Build.VERSION.SDK_INT >= 29) {return context.checkSelfPermission(Manifest.permission.ACCESS_BACKGROUND_LOCATION) == PERMISSION_GRANTED; } else { return true; } }
 	public static Boolean checkAccessNetworkState(Context context) { if ( android.os.Build.VERSION.SDK_INT >= 23) { return context.checkSelfPermission(Manifest.permission.ACCESS_NETWORK_STATE) == PERMISSION_GRANTED; } else { return true; } }
 	public static Boolean checkAccessWifiState(Context context) { if ( android.os.Build.VERSION.SDK_INT >= 23) { return context.checkSelfPermission(Manifest.permission.ACCESS_WIFI_STATE) == PERMISSION_GRANTED; } else { return true; } }
 	public static Boolean checkAccessBluetooth(Context context) { if ( android.os.Build.VERSION.SDK_INT >= 23) { return context.checkSelfPermission(Manifest.permission.BLUETOOTH) == PERMISSION_GRANTED; } else { return true; } }
@@ -103,8 +102,7 @@ public class PermissionHandler {
 
 	public static String getNextPermission(Context context, Boolean includeRecording) {
 		if (PersistentData.getGpsEnabled()) {
-			if ( !checkAccessFineLocation(context) ) return Manifest.permission.ACCESS_FINE_LOCATION;
-			if ( !checkAccessBackgroundLocation(context) && BuildConfig.READ_TEXTS_CALLS_BACKGROUND_LOCATION ) return Manifest.permission.ACCESS_BACKGROUND_LOCATION; }
+			if ( !checkAccessFineLocation(context) ) return Manifest.permission.ACCESS_FINE_LOCATION; }
 		if (PersistentData.getWifiEnabled()) {
 			if ( !checkAccessWifiState(context)) return Manifest.permission.ACCESS_WIFI_STATE;
 			if ( !checkAccessNetworkState(context)) return Manifest.permission.ACCESS_NETWORK_STATE;
@@ -113,10 +111,10 @@ public class PermissionHandler {
 		if (PersistentData.getBluetoothEnabled()) {
 			if ( !checkAccessBluetooth(context)) return Manifest.permission.BLUETOOTH;
 			if ( !checkAccessBluetoothAdmin(context)) return Manifest.permission.BLUETOOTH_ADMIN; }
-		if (PersistentData.getCallsEnabled() && BuildConfig.READ_TEXTS_CALLS_BACKGROUND_LOCATION) {
+		if (PersistentData.getCallsEnabled() && BuildConfig.READ_SMS_AND_PHONE_CALL_STATS) {
 			if ( !checkAccessReadPhoneState(context)) return Manifest.permission.READ_PHONE_STATE;  
 			if ( !checkAccessReadCallLog(context)) return Manifest.permission.READ_CALL_LOG; }
-		if (PersistentData.getTextsEnabled() && BuildConfig.READ_TEXTS_CALLS_BACKGROUND_LOCATION) {
+		if (PersistentData.getTextsEnabled() && BuildConfig.READ_SMS_AND_PHONE_CALL_STATS) {
 			if ( !checkAccessReadContacts(context)) return Manifest.permission.READ_CONTACTS;  
 			if ( !checkAccessReadSms(context)) return Manifest.permission.READ_SMS;
 			if ( !checkAccessReceiveMms(context)) return Manifest.permission.RECEIVE_MMS;

--- a/app/src/main/java/org/beiwe/app/ui/registration/RegisterActivity.java
+++ b/app/src/main/java/org/beiwe/app/ui/registration/RegisterActivity.java
@@ -193,7 +193,7 @@ public class RegisterActivity extends RunningBackgroundServiceActivity {
 		TelephonyManager phoneManager = (TelephonyManager) this.getSystemService(Context.TELEPHONY_SERVICE);
 		String phoneNumber;
 		try {
-			// If READ_TEXTS_CALLS_BACKGROUND_LOCATION is true, we should not be able to get here without having
+			// If READ_SMS_AND_PHONE_CALL_STATS is true, we should not be able to get here without having
 			// asked for the SMS permission.  If it's false, we don't have permission to do this.
 			phoneNumber = phoneManager.getLine1Number();
 		} catch (SecurityException e) {
@@ -237,7 +237,7 @@ public class RegisterActivity extends RunningBackgroundServiceActivity {
 			thisResumeCausedByFalseActivityReturn = false;
 			return;
 		}
-		if (BuildConfig.READ_TEXTS_CALLS_BACKGROUND_LOCATION &&
+		if (BuildConfig.READ_SMS_AND_PHONE_CALL_STATS &&
 				!PermissionHandler.checkAccessReadSms(getApplicationContext()) &&
 				!thisResumeCausedByFalseActivityReturn) {
 			if (shouldShowRequestPermissionRationale(Manifest.permission.READ_SMS) ) {

--- a/app/src/textsAndCallsStats/AndroidManifest.xml
+++ b/app/src/textsAndCallsStats/AndroidManifest.xml
@@ -7,6 +7,4 @@
     <uses-permission android:name="android.permission.READ_SMS" />
     <uses-permission android:name="android.permission.RECEIVE_MMS" />
     <uses-permission android:name="android.permission.RECEIVE_SMS" />
-    <!-- background location permission is forbidden for Play Store apps -->
-    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
 </manifest>

--- a/build.gradle
+++ b/build.gradle
@@ -7,8 +7,8 @@ buildscript {
         maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.1'
-        classpath 'com.google.gms:google-services:4.3.8'
+        classpath 'com.android.tools.build:gradle:7.2.1'
+        classpath 'com.google.gms:google-services:4.3.10'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jetbrains.kotlin:kotlin-android-extensions:$kotlin_version"
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip


### PR DESCRIPTION
[Google Play currently requires apps to target Android SDK level 30.](https://developer.android.com/google/play/requirements/target-sdk)  Upgrading from SDK 29 to 30 involves [several changes](https://developer.android.com/about/versions/11/behavior-changes-11), but I think the only significant one that affects Beiwe is that the [Background Location Permission becomes harder to request](https://developer.android.com/training/location/permissions#request-background-location).  The googlePlayStore and onnelaLabServer build variants of the app were requesting background location access, but I don't think they were using them, because the GPS listener runs in the foreground service, and therefore doesn't need background location permissions.  So I figured it would be easier to just remove background location permissions entirely.  I tested the googlePlayStore variant of the app for a day, and still got excellent GPS coverage.