### PR TITLE
Fix on off logging

### DIFF
--- a/app/src/main/java/org/beiwe/app/MainService.kt
+++ b/app/src/main/java/org/beiwe/app/MainService.kt
@@ -474,25 +474,21 @@ class MainService : Service() {
     ) {
         // val t1 = System.currentTimeMillis()
         if (is_running && now <= should_turn_off_at) {
-            // printw("'$identifier_string' is running, not time to turn of")
-            // printv("'$identifier_string - is running - ${System.currentTimeMillis() - t1}")
+            print("Sensor listener service is running. Next $intent_off_string is scheduled to ${convertTimestamp(should_turn_off_at)}")
             return
         }
 
         // running, should be off, off is in the past
         if (is_running && should_turn_off_at < now) {
-            // printi("'$identifier_string' time to turn off")
             off_action()
             val should_turn_on_at_safe = should_turn_on_at + 1000 // add a second to ensure we pass the timer
-            print("Sensor listener service turned off. Next $intent_on_string is scheduled to ${convertTimestamp(should_turn_on_at_safe)}")
             timer!!.setupSingleAlarmAt(should_turn_on_at_safe, Timer.intent_map[intent_on_string]!!)
-            // printv("'$identifier_string - turn off - ${System.currentTimeMillis() - t1}")
+            print("Sensor listener service turned off. Next $intent_on_string is scheduled to ${convertTimestamp(should_turn_on_at_safe)}")
         }
 
         // not_running, should turn on is still in the future, do nothing
         if (!is_running && should_turn_on_at >= now) {
-            // printw("'$identifier_string' correctly off")
-            // printv("'$identifier_string - correctly off - ${System.currentTimeMillis() - t1}")
+            print("Sensor listener service is off. Next $intent_on_string is scheduled to ${convertTimestamp(should_turn_on_at)}")
             return
         }
 
@@ -501,12 +497,10 @@ class MainService : Service() {
             // always get the current time, the now value could be stale - unlikely but possible we
             // care that we get data, not that data be rigidly accurate to a clock.
             PersistentData.setMostRecentAlarmTime(intent_on_string, System.currentTimeMillis())
-            // printe("'$identifier_string' turn it on!")
             on_action()
             val should_turn_off_at_safe = should_turn_off_at + 1000  // add a second to ensure we pass the timer
-            print("Sensor listener service turned on. Next $intent_off_string is scheduled to ${convertTimestamp(should_turn_off_at_safe)}")
             timer!!.setupSingleAlarmAt(should_turn_off_at_safe, Timer.intent_map[intent_off_string]!!)
-            // printv("'$identifier_string - on action - ${System.currentTimeMillis() - t1}")
+            print("Sensor listener service turned on. Next $intent_off_string is scheduled to ${convertTimestamp(should_turn_off_at_safe)}")
         }
     }
 

--- a/app/src/main/java/org/beiwe/app/utils.kt
+++ b/app/src/main/java/org/beiwe/app/utils.kt
@@ -1,8 +1,12 @@
 package org.beiwe.app
 
 import android.app.PendingIntent
+import android.icu.text.SimpleDateFormat
+import android.icu.util.TimeZone
 import android.os.Build
 import android.util.Log
+import java.util.Date
+import java.util.Locale
 
 // This file is a location for new static functions, further factoring into files will occur when length of file becomes a problem.
 
@@ -53,4 +57,14 @@ fun pending_intent_flag_fix(flag: Int): Int {
         return (PendingIntent.FLAG_IMMUTABLE or flag)
     else
         return flag
+}
+
+/**
+ * Converts a UTC timestamp to a human-readable date and time string, based on current device's timezone.
+ */
+fun convertTimestamp(utcTimestamp: Long): String {
+    val date = Date(utcTimestamp)
+    val dateFormat = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault())
+    dateFormat.timeZone = TimeZone.getDefault()
+    return dateFormat.format(date)
 }


### PR DESCRIPTION
Change the on-off timer logic logging into a more readable format.

Previously:
```
setting ON TIMER for Omniring On to 1733158895105
setting OFF TIMER for Omniring On to 1733158885105
```

This PR changes:
```
Sensor listener service turned off. Next Omniring On is scheduled to 2024-12-02 11:04:14
Sensor listener service turned on. Next Omniring OFF is scheduled to 2024-12-02 11:04:04
```